### PR TITLE
Use ENTRYPOINT and add CentOS builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,3 +54,38 @@ jobs:
         run: docker tag steamcmd/steamcmd:busybox steamcmd/steamcmd:lite
       - name: Push Image
         run: for TAG in busybox lite; do docker push steamcmd/steamcmd:${TAG}; done
+
+  build-centos-8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -f dockerfiles/centos-8 -t steamcmd/steamcmd:centos-8 .
+      - name: Tag Image
+        run: docker tag steamcmd/steamcmd:centos-8 steamcmd/steamcmd:centos
+      - name: Push Image
+        run: for TAG in centos-8 centos; do docker push steamcmd/steamcmd:${TAG}; done
+
+  build-centos-7:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -f dockerfiles/centos-7 -t steamcmd/steamcmd:centos-7 .
+      - name: Push Image
+        run: docker push steamcmd/steamcmd:centos-7
+
+  build-centos-6:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -f dockerfiles/centos-6 -t steamcmd/steamcmd:centos-6 .
+      - name: Push Image
+        run: docker push steamcmd/steamcmd:centos-6

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ SteamCMD with different Docker base images for downloading and running Steam gam
 
 ## Tags
 
-- [`ubuntu-18`, `ubuntu`, `latest`](dockerfiles/ubuntu-18)
-- [`ubuntu-16`](dockerfiles/ubuntu-16)
-- [`alpine`](dockerfiles/alpine)
-- [`busybox`, `lite`](dockerfiles/busybox)
-- [`centos-8`, `centos`](dockerfiles/centos-8)
-- [`centos-7`](dockerfiles/centos-7)
-- [`centos-6`](dockerfiles/centos-6)
+  - [`ubuntu-18`, `ubuntu`, `latest`](dockerfiles/ubuntu-18)
+  - [`ubuntu-16`](dockerfiles/ubuntu-16)
+  - [`alpine`](dockerfiles/alpine)
+  - [`busybox`, `lite`](dockerfiles/busybox)
+  - [`centos-8`, `centos`](dockerfiles/centos-8)
+  - [`centos-7`](dockerfiles/centos-7)
+  - [`centos-6`](dockerfiles/centos-6)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Codacy Grade](https://img.shields.io/codacy/grade/ac5825743b9643049d78279bdaa289fc)](https://www.codacy.com/gh/steamcmd/docker)
 [![Build Status](https://img.shields.io/github/workflow/status/steamcmd/docker/Build%20and%20Push%20Container.svg?logo=github)](https://github.com/steamcmd/docker/actions)
 [![Docker Pulls](https://img.shields.io/docker/pulls/steamcmd/steamcmd.svg)](https://hub.docker.com/r/steamcmd/steamcmd)
 [![Image Size](https://img.shields.io/docker/image-size/steamcmd/steamcmd.svg)](https://hub.docker.com/r/steamcmd/steamcmd)
@@ -13,6 +14,9 @@ SteamCMD with different Docker base images for downloading and running Steam gam
 - [`ubuntu-16`](dockerfiles/ubuntu-16)
 - [`alpine`](dockerfiles/alpine)
 - [`busybox`, `lite`](dockerfiles/busybox)
+- [`centos-8`, `centos`](dockerfiles/centos-8)
+- [`centos-7`](dockerfiles/centos-7)
+- [`centos-6`](dockerfiles/centos-6)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ SteamCMD with different Docker base images for downloading and running Steam gam
 
 ## Tags
 
-  - [`ubuntu-18`, `ubuntu`, `latest`](dockerfiles/ubuntu-18)
-  - [`ubuntu-16`](dockerfiles/ubuntu-16)
-  - [`alpine`](dockerfiles/alpine)
-  - [`busybox`, `lite`](dockerfiles/busybox)
-  - [`centos-8`, `centos`](dockerfiles/centos-8)
-  - [`centos-7`](dockerfiles/centos-7)
-  - [`centos-6`](dockerfiles/centos-6)
+- [`ubuntu-18`, `ubuntu`, `latest`](dockerfiles/ubuntu-18)
+- [`ubuntu-16`](dockerfiles/ubuntu-16)
+- [`alpine`](dockerfiles/alpine)
+- [`busybox`, `lite`](dockerfiles/busybox)
+- [`centos-8`, `centos`](dockerfiles/centos-8)
+- [`centos-7`](dockerfiles/centos-7)
+- [`centos-6`](dockerfiles/centos-6)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ SteamCMD with different Docker base images for downloading and running Steam gam
 
 ## Tags
 
-- [`ubuntu-18`, `ubuntu`, `latest`](dockerfiles/ubuntu-18)
-- [`ubuntu-16`](dockerfiles/ubuntu-16)
-- [`alpine`](dockerfiles/alpine)
-- [`busybox`, `lite`](dockerfiles/busybox)
-- [`centos-8`, `centos`](dockerfiles/centos-8)
-- [`centos-7`](dockerfiles/centos-7)
-- [`centos-6`](dockerfiles/centos-6)
+*   [`ubuntu-18`, `ubuntu`, `latest`](dockerfiles/ubuntu-18)
+*   [`ubuntu-16`](dockerfiles/ubuntu-16)
+*   [`alpine`](dockerfiles/alpine)
+*   [`busybox`, `lite`](dockerfiles/busybox)
+*   [`centos-8`, `centos`](dockerfiles/centos-8)
+*   [`centos-7`](dockerfiles/centos-7)
+*   [`centos-6`](dockerfiles/centos-6)
 
 ## Usage
 

--- a/dockerfiles/alpine
+++ b/dockerfiles/alpine
@@ -26,4 +26,5 @@ COPY --from=builder /lib/ld-linux.so.2  /lib/
 RUN steamcmd +quit | true
 
 # Set default command
-CMD ["steamcmd", "+help", "+quit"]
+ENTRYPOINT ["steamcmd"]
+CMD ["+help", "+quit"]

--- a/dockerfiles/centos-6
+++ b/dockerfiles/centos-6
@@ -5,21 +5,23 @@
 FROM jonakoudijs/steamcmd:latest as builder
 
 # Update SteamCMD
-RUN steamcmd +quit
+RUN +quit
 
 ######## INSTALL ########
 
 # Set the base image
-FROM busybox:1.30
+FROM centos:6
 
-# Set environment variables
-ENV LD_LIBRARY_PATH /usr/sbin
+# Install prerequisites
+RUN yum -y install glibc.i686 libstdc++.i686 \
+ && yum -y clean all
+
+ # Set environment variables
+ ENV LD_LIBRARY_PATH /usr/sbin
 
 # Copy steamcmd and required files from builder
 COPY --from=builder /root/.steam/steamcmd/linux32 /usr/sbin
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-COPY --from=builder /lib/i386-linux-gnu /lib/
-COPY --from=builder /lib/ld-linux.so.2  /lib/
 
 # Update SteamCMD and verify latest version
 # hadolint ignore=SC2216,DL4006

--- a/dockerfiles/centos-7
+++ b/dockerfiles/centos-7
@@ -10,16 +10,18 @@ RUN steamcmd +quit
 ######## INSTALL ########
 
 # Set the base image
-FROM busybox:1.30
+FROM centos:7
 
-# Set environment variables
-ENV LD_LIBRARY_PATH /usr/sbin
+# Install prerequisites
+RUN yum -y install glibc.i686 libstdc++.i686 \
+ && yum -y clean all
+
+ # Set environment variables
+ ENV LD_LIBRARY_PATH /usr/sbin
 
 # Copy steamcmd and required files from builder
 COPY --from=builder /root/.steam/steamcmd/linux32 /usr/sbin
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-COPY --from=builder /lib/i386-linux-gnu /lib/
-COPY --from=builder /lib/ld-linux.so.2  /lib/
 
 # Update SteamCMD and verify latest version
 # hadolint ignore=SC2216,DL4006

--- a/dockerfiles/centos-8
+++ b/dockerfiles/centos-8
@@ -10,16 +10,18 @@ RUN steamcmd +quit
 ######## INSTALL ########
 
 # Set the base image
-FROM busybox:1.30
+FROM centos:8
 
-# Set environment variables
-ENV LD_LIBRARY_PATH /usr/sbin
+# Install prerequisites
+RUN yum -y install glibc.i686 libstdc++.i686 \
+ && yum -y clean all
+
+ # Set environment variables
+ ENV LD_LIBRARY_PATH /usr/sbin
 
 # Copy steamcmd and required files from builder
 COPY --from=builder /root/.steam/steamcmd/linux32 /usr/sbin
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-COPY --from=builder /lib/i386-linux-gnu /lib/
-COPY --from=builder /lib/ld-linux.so.2  /lib/
 
 # Update SteamCMD and verify latest version
 # hadolint ignore=SC2216,DL4006

--- a/dockerfiles/ubuntu-16
+++ b/dockerfiles/ubuntu-16
@@ -34,4 +34,5 @@ RUN ln -s /usr/games/steamcmd /usr/bin/steamcmd
 RUN steamcmd +quit
 
 # Set default command
-CMD ["steamcmd", "+help", "+quit"]
+ENTRYPOINT ["steamcmd"]
+CMD ["+help", "+quit"]

--- a/dockerfiles/ubuntu-18
+++ b/dockerfiles/ubuntu-18
@@ -34,4 +34,5 @@ RUN ln -s /usr/games/steamcmd /usr/bin/steamcmd
 RUN steamcmd +quit
 
 # Set default command
-CMD ["steamcmd", "+help", "+quit"]
+ENTRYPOINT ["steamcmd"]
+CMD ["+help", "+quit"]


### PR DESCRIPTION
This PR will change the behaviour of the containers to start using ENTRYPOINT for `steamcmd` and the options in the CMD parameter. This PR will also add Centos builds for major version 6, 7 and 8.