### PR TITLE
Rework Alpine build to official tar installer

### DIFF
--- a/dockerfiles/alpine
+++ b/dockerfiles/alpine
@@ -1,11 +1,23 @@
 ######## BUILDER ########
 
 # Set the base image
-# hadolint ignore=DL3007
-FROM steamcmd/steamcmd:latest as builder
+FROM steamcmd/steamcmd:ubuntu-18 as builder
 
-# Update SteamCMD
-RUN steamcmd +quit
+# Set environment variables
+ENV USER root
+ENV HOME /root/installer
+
+# Set working directory
+WORKDIR $HOME
+
+# Install prerequisites
+RUN apt-get update \
+ && apt-get install -y curl tar
+
+# Donload and unpack installer
+RUN curl http://media.steampowered.com/installer/steamcmd_linux.tar.gz \
+    --output steamcmd.tar.gz --silent
+RUN tar -xvzf steamcmd.tar.gz && rm steamcmd.tar.gz
 
 ######## INSTALL ########
 
@@ -13,17 +25,29 @@ RUN steamcmd +quit
 FROM alpine:3.11
 
 # Set environment variables
-ENV LD_LIBRARY_PATH /usr/sbin
+ENV USER root
+ENV HOME /root
 
-# Copy steamcmd and required files from builder
-COPY --from=builder /root/.steam/steamcmd/linux32 /usr/sbin
+# Set working directory
+WORKDIR $HOME
+
+# Install prerequisites
+RUN apk update \
+ && apk add --no-cache bash \
+ && rm -rf /var/cache/apk/*
+
+# Copy steamcmd files from builder
+COPY --from=builder /root/installer/steamcmd.sh /usr/lib/games/steam/
+COPY --from=builder /root/installer/linux32/steamcmd /usr/lib/games/steam/
+COPY --from=builder /usr/games/steamcmd /usr/bin/steamcmd
+
+# Copy required files from builder
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /lib/i386-linux-gnu /lib/
-COPY --from=builder /lib/ld-linux.so.2  /lib/
+COPY --from=builder /root/installer/linux32/libstdc++.so.6 /lib/
 
 # Update SteamCMD and verify latest version
-# hadolint ignore=SC2216,DL4006
-RUN steamcmd +quit | true
+RUN steamcmd +quit
 
 # Set default command
 ENTRYPOINT ["steamcmd"]


### PR DESCRIPTION
Instead of purely copying the steamcmd files from the Ubuntu installation, this PR will change the behaviour to use the official steamcmd.tar.gz files and add the steamcmd wrapper script from the Ubuntu package.

This solves the exit 42 error by now using the official method of wrapper scripts (`steamcmd` + `steamcmd.sh`).