### PR TITLE
Add remaining Windows build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,74 @@ jobs:
       - name: Push Image
         run: docker push steamcmd/steamcmd:centos-6
 
+  build-windows-core-2019:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -f dockerfiles/windows-core-2019 -t steamcmd/steamcmd:windows-core-2019 .
+      - name: Tag Image
+        run: for TAG in windows-core windows; do docker tag steamcmd/steamcmd:windows-core-2019 steamcmd/steamcmd:${TAG}; done
+      - name: Push Image
+        run: for TAG in windows-core-2019 windows-core windows; do docker push steamcmd/steamcmd:${TAG}; done
+
+  build-windows-core-1909:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -f dockerfiles/windows-core-1909 -t steamcmd/steamcmd:windows-core-1909 .
+      - name: Push Image
+        run: docker push steamcmd/steamcmd:windows-core-1909
+
+  build-windows-core-1903:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -f dockerfiles/windows-core-1903 -t steamcmd/steamcmd:windows-core-1903 .
+      - name: Push Image
+        run: docker push steamcmd/steamcmd:windows-core-1903
+
+  build-windows-core-1809:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -f dockerfiles/windows-core-1809 -t steamcmd/steamcmd:windows-core-1809 .
+      - name: Push Image
+        run: docker push steamcmd/steamcmd:windows-core-1809
+
+  build-windows-1909:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -f dockerfiles/windows-1909 -t steamcmd/steamcmd:windows-1909 .
+      - name: Push Image
+        run: docker push steamcmd/steamcmd:windows-1909
+
+  build-windows-1903:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -f dockerfiles/windows-1903 -t steamcmd/steamcmd:windows-1903 .
+      - name: Push Image
+        run: docker push steamcmd/steamcmd:windows-1903
+
   build-windows-1809:
     runs-on: windows-2019
     steps:


### PR DESCRIPTION
This will add the other remaining Windows build jobs to build images for Windows Core as well as other versions (1903/1909/2019). There is a big chance that the builds of other versions will fail seeing Windows is picky on this subject. But let's try it first.