### PR TITLE
Remove Failing Windows Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,23 @@ jobs:
       - name: Push Image
         run: docker push steamcmd/steamcmd:centos-6
 
+  build-windows-1809:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -f dockerfiles/windows-1809 -t steamcmd/steamcmd:windows-1809 .
+      - name: Push Image
+        run: docker push steamcmd/steamcmd:windows-1809
+      - name: Tag Image
+        run: docker tag steamcmd/steamcmd:windows-1809 steamcmd/steamcmd:windows
+      - name: Push Image
+        run: |
+          docker push steamcmd/steamcmd:windows-1809; \
+          docker push steamcmd/steamcmd:windows
+
   build-windows-core-2019:
     runs-on: windows-2019
     steps:
@@ -104,31 +121,11 @@ jobs:
       - name: Build Image
         run: docker build -f dockerfiles/windows-core-2019 -t steamcmd/steamcmd:windows-core-2019 .
       - name: Tag Image
-        run: for TAG in windows-core windows; do docker tag steamcmd/steamcmd:windows-core-2019 steamcmd/steamcmd:${TAG}; done
+        run: docker tag steamcmd/steamcmd:windows-core-2019 steamcmd/steamcmd:windows-core
       - name: Push Image
-        run: for TAG in windows-core-2019 windows-core windows; do docker push steamcmd/steamcmd:${TAG}; done
-
-  build-windows-core-1909:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-      - name: Docker Login
-        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Build Image
-        run: docker build -f dockerfiles/windows-core-1909 -t steamcmd/steamcmd:windows-core-1909 .
-      - name: Push Image
-        run: docker push steamcmd/steamcmd:windows-core-1909
-
-  build-windows-core-1903:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-      - name: Docker Login
-        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Build Image
-        run: docker build -f dockerfiles/windows-core-1903 -t steamcmd/steamcmd:windows-core-1903 .
-      - name: Push Image
-        run: docker push steamcmd/steamcmd:windows-core-1903
+        run: |
+          docker push steamcmd/steamcmd:windows-core-2019; \
+          docker push steamcmd/steamcmd:windows-core
 
   build-windows-core-1809:
     runs-on: windows-2019
@@ -140,36 +137,3 @@ jobs:
         run: docker build -f dockerfiles/windows-core-1809 -t steamcmd/steamcmd:windows-core-1809 .
       - name: Push Image
         run: docker push steamcmd/steamcmd:windows-core-1809
-
-  build-windows-1909:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-      - name: Docker Login
-        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Build Image
-        run: docker build -f dockerfiles/windows-1909 -t steamcmd/steamcmd:windows-1909 .
-      - name: Push Image
-        run: docker push steamcmd/steamcmd:windows-1909
-
-  build-windows-1903:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-      - name: Docker Login
-        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Build Image
-        run: docker build -f dockerfiles/windows-1903 -t steamcmd/steamcmd:windows-1903 .
-      - name: Push Image
-        run: docker push steamcmd/steamcmd:windows-1903
-
-  build-windows-1809:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-      - name: Docker Login
-        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Build Image
-        run: docker build -f dockerfiles/windows-1809 -t steamcmd/steamcmd:windows-1809 .
-      - name: Push Image
-        run: docker push steamcmd/steamcmd:windows-1809

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The images are build automatically every 4 hours with [Github Actions](https://g
 *   [`windows-core-1809`](dockerfiles/windows-core-1809)
 
 > ***Note:*** *Some Windows tags are not available (yet) because they cannot be build on the current Github Actions Windows Platform.*
-> *The Dockerfiles are added to this repository so builds can be done locally and it's ready when Github Action supports newer Windows versions.*
+> *The Dockerfiles are added to this repository to be able to build manually and for the moment that Github Actions supports newer Windows versions.*
 > *See [this article](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility) on the Microsoft docs for more information on the subject.*
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ SteamCMD on various Docker base images for downloading and running Steam games a
 *   [`centos-8`, `centos`](dockerfiles/centos-8)
 *   [`centos-7`](dockerfiles/centos-7)
 *   [`centos-6`](dockerfiles/centos-6)
-*   [`windows-core-2019`, `windows-core`, `windows`](dockerfiles/windows-core-2019)
+*   [`windows-1909`](dockerfiles/windows-1909)
+*   [`windows-1903`](dockerfiles/windows-1903)
+*   [`windows-1809`, `windows`](dockerfiles/windows-1809)
+*   [`windows-core-2019`, `windows-core`](dockerfiles/windows-core-2019)
 *   [`windows-core-1909`](dockerfiles/windows-core-1909)
 *   [`windows-core-1903`](dockerfiles/windows-core-1903)
 *   [`windows-core-1809`](dockerfiles/windows-core-1809)
-*   [`windows-1909`](dockerfiles/windows-1909)
-*   [`windows-1903`](dockerfiles/windows-1903)
-*   [`windows-1809`](dockerfiles/windows-1809)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 # SteamCMD Docker Image
 
-SteamCMD on various Docker base images for downloading and running Steam games and game server software. The images are build automatically every 4 hours with [Github Actions](https://github.com/steamcmd/docker/actions) and tagged on type of base image.
+SteamCMD on various Docker base images for downloading and running Steam games and game server software.
+The images are build automatically every 4 hours with [Github Actions](https://github.com/steamcmd/docker/actions) and tagged on type of base image.
 
 ## Tags
 
@@ -17,13 +18,17 @@ SteamCMD on various Docker base images for downloading and running Steam games a
 *   [`centos-8`, `centos`](dockerfiles/centos-8)
 *   [`centos-7`](dockerfiles/centos-7)
 *   [`centos-6`](dockerfiles/centos-6)
-*   [`windows-1909`](dockerfiles/windows-1909)
-*   [`windows-1903`](dockerfiles/windows-1903)
+*   [`windows-1909`](dockerfiles/windows-1909) *(unavailable)*
+*   [`windows-1903`](dockerfiles/windows-1903) *(unavailable)*
 *   [`windows-1809`, `windows`](dockerfiles/windows-1809)
 *   [`windows-core-2019`, `windows-core`](dockerfiles/windows-core-2019)
-*   [`windows-core-1909`](dockerfiles/windows-core-1909)
-*   [`windows-core-1903`](dockerfiles/windows-core-1903)
+*   [`windows-core-1909`](dockerfiles/windows-core-1909) *(unavailable)*
+*   [`windows-core-1903`](dockerfiles/windows-core-1903) *(unavailable)*
 *   [`windows-core-1809`](dockerfiles/windows-core-1809)
+
+> ***Note:*** *Some Windows tags are not available (yet) because they cannot be build on the current Github Actions Windows Platform.*
+> *The Dockerfiles are added to this repository so builds can be done locally and it's ready when Github Action supports newer Windows versions.*
+> *See [this article](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility) on the Microsoft docs for more information on the subject.*
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The images are build automatically every 4 hours with [Github Actions](https://g
 *   [`windows-core-1809`](dockerfiles/windows-core-1809)
 
 > ***Note:*** *Some Windows tags are not available (yet) because they cannot be build on the current Github Actions Windows Platform.*
-> *The Dockerfiles are added to this repository to be able to build manually and for the moment that Github Actions supports newer Windows versions.*
+> *The Dockerfiles are added to this repository to be able to build manually and for the moment when Github Actions supports newer Windows versions.*
 > *See [this article](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility) on the Microsoft docs for more information on the subject.*
 
 ## Usage


### PR DESCRIPTION
The available Github Actions Windows build platform does not support newer versions then 1809. This PR removes the failing builds from the action config. The Dockerfiles will be kept in the repository to allow for personal/local/manual builds in a different environment.

Also the README is updated with to show which tags are unavailable at this moment and a warning explaining this behaviour is added.