### PR TITLE
Rework CentOS Dockerfiles

### DIFF
--- a/dockerfiles/centos-6
+++ b/dockerfiles/centos-6
@@ -1,31 +1,48 @@
 ######## BUILDER ########
 
 # Set the base image
-# hadolint ignore=DL3007
-FROM steamcmd/steamcmd:latest as builder
+FROM steamcmd/steamcmd:ubuntu-18 as builder
 
-# Update SteamCMD
-RUN steamcmd +quit
+# Set environment variables
+ENV USER root
+ENV HOME /root/installer
+
+# Set working directory
+WORKDIR $HOME
+
+# Install prerequisites
+RUN apt-get update \
+ && apt-get install -y curl tar
+
+# Donload and unpack installer
+RUN curl http://media.steampowered.com/installer/steamcmd_linux.tar.gz \
+    --output steamcmd.tar.gz --silent
+RUN tar -xvzf steamcmd.tar.gz && rm steamcmd.tar.gz
 
 ######## INSTALL ########
 
 # Set the base image
 FROM centos:6
 
+# Set environment variables
+ENV USER root
+ENV HOME /root
+
 # Install prerequisites
 RUN yum -y install glibc.i686 libstdc++.i686 \
  && yum -y clean all
 
-# Set environment variables
-ENV LD_LIBRARY_PATH /usr/sbin
+# Copy steamcmd files from builder
+COPY --from=builder /root/installer/steamcmd.sh /usr/lib/games/steam/
+COPY --from=builder /root/installer/linux32/steamcmd /usr/lib/games/steam/
+COPY --from=builder /usr/games/steamcmd /usr/bin/steamcmd
 
-# Copy steamcmd and required files from builder
-COPY --from=builder /root/.steam/steamcmd/linux32 /usr/sbin
+# Copy required files from builder
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /root/installer/linux32/libstdc++.so.6 /lib/
 
 # Update SteamCMD and verify latest version
-# hadolint ignore=SC2216,DL4006
-RUN steamcmd +quit | true
+RUN steamcmd +quit
 
 # Set default command
 ENTRYPOINT ["steamcmd"]

--- a/dockerfiles/centos-7
+++ b/dockerfiles/centos-7
@@ -1,31 +1,48 @@
 ######## BUILDER ########
 
 # Set the base image
-# hadolint ignore=DL3007
-FROM steamcmd/steamcmd:latest as builder
+FROM steamcmd/steamcmd:ubuntu-18 as builder
 
-# Update SteamCMD
-RUN steamcmd +quit
+# Set environment variables
+ENV USER root
+ENV HOME /root/installer
+
+# Set working directory
+WORKDIR $HOME
+
+# Install prerequisites
+RUN apt-get update \
+ && apt-get install -y curl tar
+
+# Donload and unpack installer
+RUN curl http://media.steampowered.com/installer/steamcmd_linux.tar.gz \
+    --output steamcmd.tar.gz --silent
+RUN tar -xvzf steamcmd.tar.gz && rm steamcmd.tar.gz
 
 ######## INSTALL ########
 
 # Set the base image
 FROM centos:7
 
+# Set environment variables
+ENV USER root
+ENV HOME /root
+
 # Install prerequisites
 RUN yum -y install glibc.i686 libstdc++.i686 \
  && yum -y clean all
 
-# Set environment variables
-ENV LD_LIBRARY_PATH /usr/sbin
+# Copy steamcmd files from builder
+COPY --from=builder /root/installer/steamcmd.sh /usr/lib/games/steam/
+COPY --from=builder /root/installer/linux32/steamcmd /usr/lib/games/steam/
+COPY --from=builder /usr/games/steamcmd /usr/bin/steamcmd
 
-# Copy steamcmd and required files from builder
-COPY --from=builder /root/.steam/steamcmd/linux32 /usr/sbin
+# Copy required files from builder
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /root/installer/linux32/libstdc++.so.6 /lib/
 
 # Update SteamCMD and verify latest version
-# hadolint ignore=SC2216,DL4006
-RUN steamcmd +quit | true
+RUN steamcmd +quit
 
 # Set default command
 ENTRYPOINT ["steamcmd"]

--- a/dockerfiles/centos-8
+++ b/dockerfiles/centos-8
@@ -1,31 +1,48 @@
 ######## BUILDER ########
 
 # Set the base image
-# hadolint ignore=DL3007
-FROM steamcmd/steamcmd:latest as builder
+FROM steamcmd/steamcmd:ubuntu-18 as builder
 
-# Update SteamCMD
-RUN steamcmd +quit
+# Set environment variables
+ENV USER root
+ENV HOME /root/installer
+
+# Set working directory
+WORKDIR $HOME
+
+# Install prerequisites
+RUN apt-get update \
+ && apt-get install -y curl tar
+
+# Donload and unpack installer
+RUN curl http://media.steampowered.com/installer/steamcmd_linux.tar.gz \
+    --output steamcmd.tar.gz --silent
+RUN tar -xvzf steamcmd.tar.gz && rm steamcmd.tar.gz
 
 ######## INSTALL ########
 
 # Set the base image
 FROM centos:8
 
+# Set environment variables
+ENV USER root
+ENV HOME /root
+
 # Install prerequisites
 RUN yum -y install glibc.i686 libstdc++.i686 \
  && yum -y clean all
 
-# Set environment variables
-ENV LD_LIBRARY_PATH /usr/sbin
+# Copy steamcmd files from builder
+COPY --from=builder /root/installer/steamcmd.sh /usr/lib/games/steam/
+COPY --from=builder /root/installer/linux32/steamcmd /usr/lib/games/steam/
+COPY --from=builder /usr/games/steamcmd /usr/bin/steamcmd
 
-# Copy steamcmd and required files from builder
-COPY --from=builder /root/.steam/steamcmd/linux32 /usr/sbin
+# Copy required files from builder
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /root/installer/linux32/libstdc++.so.6 /lib/
 
 # Update SteamCMD and verify latest version
-# hadolint ignore=SC2216,DL4006
-RUN steamcmd +quit | true
+RUN steamcmd +quit
 
 # Set default command
 ENTRYPOINT ["steamcmd"]


### PR DESCRIPTION
This will change the CentOS image version builds to use the offical `steamcmd.tar.gz` installer. Now the first run of `steamcmd +quit` will run succesfully instead of throwing an exit code of **42**.