### PR TITLE
Add (d)goss testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,91 +9,126 @@ on:
 jobs:
   build-ubuntu-18:
     runs-on: ubuntu-18.04
+    env:
+      IMAGE_TAG: "ubuntu-18"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
-        run: docker build -f dockerfiles/ubuntu-18 -t steamcmd/steamcmd:ubuntu-18 .
+        run: docker build -f dockerfiles/$IMAGE_TAG -t steamcmd/steamcmd:$IMAGE_TAG .
+      - name: Test Image
+        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Tag Image
-        run: for TAG in ubuntu latest; do docker tag steamcmd/steamcmd:ubuntu-18 steamcmd/steamcmd:${TAG}; done
+        run: for TAG in ubuntu latest; do docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:${TAG}; done
       - name: Push Image
-        run: for TAG in ubuntu-18 ubuntu latest; do docker push steamcmd/steamcmd:${TAG}; done
+        run: for TAG in $IMAGE_TAG ubuntu latest; do docker push steamcmd/steamcmd:${TAG}; done
 
   build-ubuntu-16:
     runs-on: ubuntu-18.04
+    env:
+      IMAGE_TAG: "ubuntu-16"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
-        run: docker build -f dockerfiles/ubuntu-16 -t steamcmd/steamcmd:ubuntu-16 .
+        run: docker build -f dockerfiles/$IMAGE_TAG -t steamcmd/steamcmd:$IMAGE_TAG .
+      - name: Test Image
+        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Push Image
-        run: docker push steamcmd/steamcmd:ubuntu-16
+        run: docker push steamcmd/steamcmd:$IMAGE_TAG
 
   build-alpine:
     runs-on: ubuntu-18.04
     needs: build-ubuntu-18
+    env:
+      IMAGE_TAG: "alpine"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
-        run: docker build -f dockerfiles/alpine -t steamcmd/steamcmd:alpine .
+        run: docker build -f dockerfiles/$IMAGE_TAG -t steamcmd/steamcmd:$IMAGE_TAG .
+      - name: Test Image
+        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Push Image
-        run: docker push steamcmd/steamcmd:alpine
+        run: docker push steamcmd/steamcmd:$IMAGE_TAG
 
   build-busybox:
     runs-on: ubuntu-18.04
     needs: build-ubuntu-18
+    env:
+      IMAGE_TAG: "busybox"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
-        run: docker build -f dockerfiles/busybox -t steamcmd/steamcmd:busybox .
+        run: docker build -f dockerfiles/$IMAGE_TAG -t steamcmd/steamcmd:$IMAGE_TAG .
+      - name: Test Image
+        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Tag Image
-        run: docker tag steamcmd/steamcmd:busybox steamcmd/steamcmd:lite
+        run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:lite
       - name: Push Image
-        run: for TAG in busybox lite; do docker push steamcmd/steamcmd:${TAG}; done
+        run: for TAG in $IMAGE_TAG lite; do docker push steamcmd/steamcmd:${TAG}; done
 
   build-centos-8:
     runs-on: ubuntu-18.04
     needs: build-ubuntu-18
+    env:
+      IMAGE_TAG: "centos-8"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
-        run: docker build -f dockerfiles/centos-8 -t steamcmd/steamcmd:centos-8 .
+        run: docker build -f dockerfiles/$IMAGE_TAG -t steamcmd/steamcmd:$IMAGE_TAG .
+      - name: Test Image
+        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Tag Image
-        run: docker tag steamcmd/steamcmd:centos-8 steamcmd/steamcmd:centos
+        run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:centos
       - name: Push Image
-        run: for TAG in centos-8 centos; do docker push steamcmd/steamcmd:${TAG}; done
+        run: for TAG in $IMAGE_TAG centos; do docker push steamcmd/steamcmd:${TAG}; done
 
   build-centos-7:
     runs-on: ubuntu-18.04
     needs: build-ubuntu-18
+    env:
+      IMAGE_TAG: "centos-7"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
-        run: docker build -f dockerfiles/centos-7 -t steamcmd/steamcmd:centos-7 .
+        run: docker build -f dockerfiles/$IMAGE_TAG -t steamcmd/steamcmd:$IMAGE_TAG .
+      - name: Test Image
+        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Push Image
-        run: docker push steamcmd/steamcmd:centos-7
+        run: docker push steamcmd/steamcmd:$IMAGE_TAG
 
   build-centos-6:
     runs-on: ubuntu-18.04
     needs: build-ubuntu-18
+    env:
+      IMAGE_TAG: "centos-6"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
-        run: docker build -f dockerfiles/centos-6 -t steamcmd/steamcmd:centos-6 .
+        run: docker build -f dockerfiles/$IMAGE_TAG -t steamcmd/steamcmd:$IMAGE_TAG .
+      - name: Test Image
+        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Push Image
-        run: docker push steamcmd/steamcmd:centos-6
+        run: docker push steamcmd/steamcmd:$IMAGE_TAG
 
   build-windows-1809:
     runs-on: windows-2019

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,8 @@ jobs:
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
         run: docker build -f dockerfiles/windows-1809 -t steamcmd/steamcmd:windows-1809 .
+      - name: Test Image
+        run: docker run steamcmd/steamcmd:windows-1809
       - name: Tag Image
         run: docker tag steamcmd/steamcmd:windows-1809 steamcmd/steamcmd:windows
       - name: Push Image
@@ -153,6 +155,8 @@ jobs:
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
         run: docker build -f dockerfiles/windows-core-2019 -t steamcmd/steamcmd:windows-core-2019 .
+      - name: Test Image
+        run: docker run steamcmd/steamcmd:windows-core-2019
       - name: Tag Image
         run: docker tag steamcmd/steamcmd:windows-core-2019 steamcmd/steamcmd:windows-core
       - name: Push Image
@@ -168,5 +172,7 @@ jobs:
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
         run: docker build -f dockerfiles/windows-core-1809 -t steamcmd/steamcmd:windows-core-1809 .
+      - name: Test Image
+        run: docker run steamcmd/steamcmd:windows-core-1809
       - name: Push Image
         run: docker push steamcmd/steamcmd:windows-core-1809

--- a/goss.yml
+++ b/goss.yml
@@ -1,0 +1,20 @@
+file:
+  /usr/bin/steamcmd:
+    # required attributes
+    exists: true
+
+command:
+  steamcmd:
+    # required attributes
+    exit-status: 0
+    # defaults to hash key
+    exec: "steamcmd +quit"
+
+    # required output
+    stdout:
+      - "OK."
+
+    # optional attributes
+    stderr: []
+    timeout: 60000 # in milliseconds
+    skip: false


### PR DESCRIPTION
This will add some basic [goss](https://github.com/aelsabbahy/goss) testing. This PR will add testing support for Linux (in the build workflow). Also added simple `docker run` commands to the Windows jobs to have some minimal testing for the Windows images as well.