### PR TITLE
Fix goss action syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       IMAGE_TAG: "ubuntu-18"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action
+      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -31,7 +31,7 @@ jobs:
       IMAGE_TAG: "ubuntu-16"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action
+      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -48,7 +48,7 @@ jobs:
       IMAGE_TAG: "alpine"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action
+      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -65,7 +65,7 @@ jobs:
       IMAGE_TAG: "busybox"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action
+      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -84,7 +84,7 @@ jobs:
       IMAGE_TAG: "centos-8"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action
+      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -103,7 +103,7 @@ jobs:
       IMAGE_TAG: "centos-7"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action
+      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -120,7 +120,7 @@ jobs:
       IMAGE_TAG: "centos-6"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action
+      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image


### PR DESCRIPTION
Follow-up to [PR 26](https://github.com/steamcmd/docker/pull/26). Fixes syntax of the dgoss `use`.