### PR TITLE
Enable build and test for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   schedule:
     - cron: '0 */4 * * *'
 
@@ -21,9 +24,13 @@ jobs:
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
         run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
+      # master
       - name: Tag Image
+        if: ${{ github.ref == 'master' }}
         run: for TAG in ubuntu latest; do docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:${TAG}; done
+
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: for TAG in $IMAGE_TAG ubuntu latest; do docker push steamcmd/steamcmd:${TAG}; done
 
   build-ubuntu-16:
@@ -41,6 +48,7 @@ jobs:
       - name: Test Image
         run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: docker push steamcmd/steamcmd:$IMAGE_TAG
 
   build-alpine-3:
@@ -59,8 +67,10 @@ jobs:
       - name: Test Image
         run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Tag Image
+        if: ${{ github.ref == 'master' }}
         run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:alpine
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: for TAG in $IMAGE_TAG alpine; do docker push steamcmd/steamcmd:${TAG}; done
 
   build-centos-8:
@@ -79,8 +89,10 @@ jobs:
       - name: Test Image
         run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Tag Image
+        if: ${{ github.ref == 'master' }}
         run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:centos
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: for TAG in $IMAGE_TAG centos; do docker push steamcmd/steamcmd:${TAG}; done
 
   build-centos-7:
@@ -99,6 +111,7 @@ jobs:
       - name: Test Image
         run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: docker push steamcmd/steamcmd:$IMAGE_TAG
 
   build-centos-6:
@@ -117,6 +130,7 @@ jobs:
       - name: Test Image
         run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: docker push steamcmd/steamcmd:$IMAGE_TAG
 
   build-windows-1809:
@@ -131,10 +145,13 @@ jobs:
       - name: Test Image
         run: docker run steamcmd/steamcmd:windows-1809 +quit
       - name: Tag Image
+        if: ${{ github.ref == 'master' }}
         run: docker tag steamcmd/steamcmd:windows-1809 steamcmd/steamcmd:windows
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: docker push steamcmd/steamcmd:windows-1809
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: docker push steamcmd/steamcmd:windows
 
   build-windows-core-2019:
@@ -149,10 +166,13 @@ jobs:
       - name: Test Image
         run: docker run steamcmd/steamcmd:windows-core-2019 +quit
       - name: Tag Image
+        if: ${{ github.ref == 'master' }}
         run: docker tag steamcmd/steamcmd:windows-core-2019 steamcmd/steamcmd:windows-core
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: docker push steamcmd/steamcmd:windows-core-2019
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: docker push steamcmd/steamcmd:windows-core
 
   build-windows-core-1809:
@@ -167,4 +187,5 @@ jobs:
       - name: Test Image
         run: docker run steamcmd/steamcmd:windows-core-1809 +quit
       - name: Push Image
+        if: ${{ github.ref == 'master' }}
         run: docker push steamcmd/steamcmd:windows-core-1809


### PR DESCRIPTION
Building and testing (and pushing) are only done when pushed/merged to master. The building and testing jobs should also be done with pull requests to catch build errors earlier.