### PR TITLE
Fix CentOS 8 GCC build error

### DIFF
--- a/dockerfiles/centos-8/Dockerfile
+++ b/dockerfiles/centos-8/Dockerfile
@@ -29,7 +29,7 @@ ENV USER root
 ENV HOME /root
 
 # Install prerequisites
-RUN yum -y install glibc.i686 libstdc++.i686 \
+RUN yum -y install glibc.i686 libgcc.i686 \
  && yum -y clean all
 
 # Copy steamcmd files from builder


### PR DESCRIPTION
This error will replace the `libstdc++.i686` package with`libgcc.i686` package to fix the build errors that recently started to appear.