### PR TITLE
Disable broken goss action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
       IMAGE_TAG: "ubuntu-18"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -38,7 +37,6 @@ jobs:
       IMAGE_TAG: "ubuntu-16"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -57,7 +55,6 @@ jobs:
       IMAGE_TAG: "alpine-3"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -79,7 +76,6 @@ jobs:
       IMAGE_TAG: "centos-8"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -101,7 +97,6 @@ jobs:
       IMAGE_TAG: "centos-7"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
@@ -120,7 +115,6 @@ jobs:
       IMAGE_TAG: "centos-6"
     steps:
       - uses: actions/checkout@v2
-      - uses: e1himself/goss-installation-action@v1
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
+        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
       # master
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
@@ -45,7 +45,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
+        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker push steamcmd/steamcmd:$IMAGE_TAG
@@ -64,7 +64,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
+        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:alpine
@@ -86,7 +86,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
+        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:centos
@@ -108,7 +108,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
+        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker push steamcmd/steamcmd:$IMAGE_TAG
@@ -127,7 +127,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run --entrypoint="" steamcmd/steamcmd:$IMAGE_TAG sleep 120
+        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker push steamcmd/steamcmd:$IMAGE_TAG


### PR DESCRIPTION
The used "goss" action is broken, see [issue 40](https://github.com/steamcmd/docker/issues/40). This PR will (temporarily) disable this action to make sure the builds can continue running. This action comes from the marketplace and does not yet contain a newer version that would fix this issue.