### PR TITLE
Reinstate goss test action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG --entrypoint=""
       # master
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
@@ -49,7 +49,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG --entrypoint=""
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker push steamcmd/steamcmd:$IMAGE_TAG
@@ -70,7 +70,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG --entrypoint=""
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:alpine
@@ -94,7 +94,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG --entrypoint=""
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:centos
@@ -118,7 +118,7 @@ jobs:
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG --entrypoint=""
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker push steamcmd/steamcmd:$IMAGE_TAG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,16 @@ jobs:
       IMAGE_TAG: "ubuntu-18"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action@v1.0.3
+        with:
+          version: 'v0.3.14'
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG
       # master
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
@@ -37,13 +40,16 @@ jobs:
       IMAGE_TAG: "ubuntu-16"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action@v1.0.3
+        with:
+          version: 'v0.3.14'
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker push steamcmd/steamcmd:$IMAGE_TAG
@@ -55,13 +61,16 @@ jobs:
       IMAGE_TAG: "alpine-3"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action@v1.0.3
+        with:
+          version: 'v0.3.14'
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:alpine
@@ -76,13 +85,16 @@ jobs:
       IMAGE_TAG: "centos-8"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action@v1.0.3
+        with:
+          version: 'v0.3.14'
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:centos
@@ -97,13 +109,16 @@ jobs:
       IMAGE_TAG: "centos-7"
     steps:
       - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action@v1.0.3
+        with:
+          version: 'v0.3.14'
       - name: Docker Login
         run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Build Image
         run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
         working-directory: dockerfiles/${{ env.IMAGE_TAG }}
       - name: Test Image
-        run: docker run steamcmd/steamcmd:$IMAGE_TAG +quit
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker push steamcmd/steamcmd:$IMAGE_TAG


### PR DESCRIPTION
Last month the [goss-installation-action](https://github.com/marketplace/actions/install-goss) has been fixed and this PR will reinstate the goss action and the corresponding test (replacing the temporary docker run job as a poor mans test step).