### PR TITLE
Fix stdout goss test search

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -12,7 +12,7 @@ command:
 
     # required output
     stdout:
-      - "OK."
+      - "Loading Steam API...OK"
 
     # optional attributes
     stderr: []


### PR DESCRIPTION
The `steamcmd +quit` output seems to be changed slightly that causes the stdout test in **goss** to fail. This PR will change the string. Today I ran the `steamcmd +quit` again and used the last OK string from the output:
```
=> $ docker run -ti steamcmd/steamcmd:latest +quit
Redirecting stderr to '/root/.steam/logs/stderr.txt'
[  0%] Checking for available updates...
[----] Downloading update (0 of 16,377 KB)...
[  0%] Downloading update (1,211 of 16,377 KB)...
[  7%] Downloading update (2,519 of 16,377 KB)...
[ 15%] Downloading update (3,959 of 16,377 KB)...
[ 24%] Downloading update (5,270 of 16,377 KB)...
[ 32%] Downloading update (6,580 of 16,377 KB)...
[ 40%] Downloading update (7,882 of 16,377 KB)...
[ 48%] Downloading update (9,314 of 16,377 KB)...
[ 56%] Downloading update (10,615 of 16,377 KB)...
[ 64%] Downloading update (11,913 of 16,377 KB)...
[ 72%] Downloading update (13,196 of 16,377 KB)...
[ 80%] Downloading update (14,622 of 16,377 KB)...
[ 89%] Downloading update (15,923 of 16,377 KB)...
[ 97%] Downloading update (16,377 of 16,377 KB)...
[100%] Download complete.
[----] Installing update...
[----] Extracting package...
[----] Extracting package...
[----] Extracting package...
[----] Extracting package...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Cleaning up...
[----] Update complete, launching Steamcmd...
Redirecting stderr to '/root/.steam/logs/stderr.txt'
[  0%] Checking for available updates...
[----] Verifying installation...
Steam Console Client (c) Valve Corporation
-- type 'quit' to exit --
Loading Steam API...OK
```