### PR TITLE
Add keepalive workflow action

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,12 @@
+name: Keepalive Workflows
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  create-keepalive-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Keepalive Commit
+        uses: gautamkrishnar/keepalive-workflow@master


### PR DESCRIPTION
As discovered in issue https://github.com/steamcmd/docker/issues/54 apparently Github automatically pauzes Github Action workflows when there has not been any (commit) activity in the repo for 60 days.

This MR will add an action that checks every night if there has not been a commit for a while and will then make a dummy commit to circumvent the 60 days limitation.