### PR TITLE
Add support for Rocky Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,31 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         run: for TAG in $IMAGE_TAG alpine; do docker push steamcmd/steamcmd:${TAG}; done
 
+  build-rocky-8:
+    runs-on: ubuntu-18.04
+    needs: build-ubuntu-18
+    env:
+      IMAGE_TAG: "rocky-8"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action@v1.0.3
+        with:
+          version: 'v0.3.14'
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
+        working-directory: dockerfiles/${{ env.IMAGE_TAG }}
+      - name: Test Image
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG --entrypoint=""
+      # master
+      - name: Tag Image
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:rocky
+      - name: Push Image
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: for TAG in $IMAGE_TAG centos; do docker push steamcmd/steamcmd:${TAG}; done
+
   build-centos-8:
     runs-on: ubuntu-18.04
     needs: build-ubuntu-18

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,2 @@
+ignored:
+  - DL3033 # Pin versions in yum

--- a/dockerfiles/rocky-8/Dockerfile
+++ b/dockerfiles/rocky-8/Dockerfile
@@ -1,0 +1,49 @@
+######## BUILDER ########
+
+# Set the base image
+FROM steamcmd/steamcmd:ubuntu-18 as builder
+
+# Set environment variables
+ENV USER root
+ENV HOME /root/installer
+
+# Set working directory
+WORKDIR $HOME
+
+# Install prerequisites
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl tar
+
+# Donload and unpack installer
+RUN curl http://media.steampowered.com/installer/steamcmd_linux.tar.gz \
+    --output steamcmd.tar.gz --silent
+RUN tar -xvzf steamcmd.tar.gz && rm steamcmd.tar.gz
+
+######## INSTALL ########
+
+# Set the base image
+FROM rockylinux:8
+
+# Set environment variables
+ENV USER root
+ENV HOME /root
+
+# Install prerequisites
+RUN yum -y install glibc.i686 libgcc.i686 \
+ && yum -y clean all
+
+# Copy steamcmd files from builder
+COPY --from=builder /root/installer/steamcmd.sh /usr/lib/games/steam/
+COPY --from=builder /root/installer/linux32/steamcmd /usr/lib/games/steam/
+COPY --from=builder /usr/games/steamcmd /usr/bin/steamcmd
+
+# Copy required files from builder
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /root/installer/linux32/libstdc++.so.6 /lib/
+
+# Update SteamCMD and verify latest version
+RUN steamcmd +quit
+
+# Set default command
+ENTRYPOINT ["steamcmd"]
+CMD ["+help", "+quit"]


### PR DESCRIPTION
Seeing CentOS support will be dropped at some point (not really clear on the Docker images though) I will add Rocky Linux as a base image seeing this is a drop-in replacement for CentOS and does not use the CentOS Stream method which might be translated to their Docker images as well.