### PR TITLE
Add CentOS Stream images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       IMAGE_TAG: "ubuntu-20"
+      IMAGE_TAG_ALT: "ubuntu"
     steps:
       - uses: actions/checkout@v2
       - uses: e1himself/goss-installation-action@v1.0.3
@@ -29,10 +30,10 @@ jobs:
       # master
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: for TAG in ubuntu latest; do docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:${TAG}; done
+        run: for TAG in $IMAGE_TAG_ALT latest; do docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:${TAG}; done
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: for TAG in $IMAGE_TAG ubuntu latest; do docker push steamcmd/steamcmd:${TAG}; done
+        run: for TAG in $IMAGE_TAG $IMAGE_TAG_ALT latest; do docker push steamcmd/steamcmd:${TAG}; done
 
   build-ubuntu-18:
     runs-on: ubuntu-18.04
@@ -81,6 +82,7 @@ jobs:
     needs: build-ubuntu-18
     env:
       IMAGE_TAG: "alpine-3"
+      IMAGE_TAG_ALT: "alpine"
     steps:
       - uses: actions/checkout@v2
       - uses: e1himself/goss-installation-action@v1.0.3
@@ -96,16 +98,17 @@ jobs:
       # master
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:alpine
+        run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:$IMAGE_TAG_ALT
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: for TAG in $IMAGE_TAG alpine; do docker push steamcmd/steamcmd:${TAG}; done
+        run: for TAG in $IMAGE_TAG $IMAGE_TAG_ALT; do docker push steamcmd/steamcmd:${TAG}; done
 
   build-rocky-8:
     runs-on: ubuntu-18.04
     needs: build-ubuntu-18
     env:
       IMAGE_TAG: "rocky-8"
+      IMAGE_TAG_ALT: "rocky"
     steps:
       - uses: actions/checkout@v2
       - uses: e1himself/goss-installation-action@v1.0.3
@@ -121,16 +124,65 @@ jobs:
       # master
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:rocky
+        run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:$IMAGE_TAG_ALT
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: for TAG in $IMAGE_TAG rocky; do docker push steamcmd/steamcmd:${TAG}; done
+        run: for TAG in $IMAGE_TAG $IMAGE_TAG_ALT; do docker push steamcmd/steamcmd:${TAG}; done
+
+  build-centos-stream-9:
+    runs-on: ubuntu-18.04
+    needs: build-ubuntu-18
+    env:
+      IMAGE_TAG: "centos-stream-9"
+      IMAGE_TAG_ALT: "centos-stream"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action@v1.0.3
+        with:
+          version: 'v0.3.14'
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
+        working-directory: dockerfiles/${{ env.IMAGE_TAG }}
+      - name: Test Image
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG --entrypoint=""
+      # master
+      - name: Tag Image
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:$IMAGE_TAG_ALT
+      - name: Push Image
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: for TAG in $IMAGE_TAG $IMAGE_TAG_ALT; do docker push steamcmd/steamcmd:${TAG}; done
+
+  build-centos-stream-8:
+    runs-on: ubuntu-18.04
+    needs: build-ubuntu-18
+    env:
+      IMAGE_TAG: "centos-stream-8"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action@v1.0.3
+        with:
+          version: 'v0.3.14'
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
+        working-directory: dockerfiles/${{ env.IMAGE_TAG }}
+      - name: Test Image
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG --entrypoint=""
+      # master
+      - name: Push Image
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: docker push steamcmd/steamcmd:$IMAGE_TAG
 
   build-centos-8:
     runs-on: ubuntu-18.04
     needs: build-ubuntu-18
     env:
       IMAGE_TAG: "centos-8"
+      IMAGE_TAG_ALT: "centos"
     steps:
       - uses: actions/checkout@v2
       - uses: e1himself/goss-installation-action@v1.0.3
@@ -146,10 +198,10 @@ jobs:
       # master
       - name: Tag Image
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:centos
+        run: docker tag steamcmd/steamcmd:$IMAGE_TAG steamcmd/steamcmd:$IMAGE_TAG_ALT
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: for TAG in $IMAGE_TAG centos; do docker push steamcmd/steamcmd:${TAG}; done
+        run: for TAG in $IMAGE_TAG $IMAGE_TAG_ALT; do docker push steamcmd/steamcmd:${TAG}; done
 
   build-centos-7:
     runs-on: ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ have a look at [steamcmd.net](https://www.steamcmd.net).
 *   [`ubuntu-16`](dockerfiles/ubuntu-16/Dockerfile)
 *   [`alpine-3`, `alpine`](dockerfiles/alpine-3/Dockerfile)
 *   [`rocky-8`, `rocky`](dockerfiles/rocky-8/Dockerfile)
+*   [`centos-stream-9`, `centos-stream`](dockerfiles/centos-stream-9/Dockerfile)
+*   [`centos-stream-8`](dockerfiles/centos-7/Dockerfile)
 *   [`centos-8`, `centos`](dockerfiles/centos-8/Dockerfile)
 *   [`centos-7`](dockerfiles/centos-7/Dockerfile)
 *   [`windows-1909`](dockerfiles/windows-1909/Dockerfile) *(unavailable)*
@@ -34,9 +36,18 @@ have a look at [steamcmd.net](https://www.steamcmd.net).
 *   [`windows-core-1903`](dockerfiles/windows-core-1903/Dockerfile) *(unavailable)*
 *   [`windows-core-1809`](dockerfiles/windows-core-1809/Dockerfile)
 
-> ***Note:*** *Some Windows tags are not available (yet) because they cannot be build on the current Github Actions Windows Platform.*
-> *The Dockerfiles are added to this repository to be able to build manually and for the moment when Github Actions supports newer Windows versions.*
-> *See [this article](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility) on the Microsoft docs for more information on the subject.*
+> ***Note:***
+> *Some Windows tags are not available (yet) because they cannot be*
+> *build on the current Github Actions Windows Platform. The Dockerfiles are
+> *added to this repository to be able to build manually and for the moment when*
+> *Github Actions supports newer Windows versions. See*
+> *[this article](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility)*
+> *on the Microsoft docs for more information on the subject.*
+
+> ***Note:***
+> *Regular CentOS images and CentOS Stream images are currently build and tagged*
+> *separately. Eventually the Stream images will replace the regular CentOS tags*
+> *As an alternative to CentOS Stream, Rocky Linux images are also available.*
 
 ## Usage
 

--- a/dockerfiles/centos-stream-8/Dockerfile
+++ b/dockerfiles/centos-stream-8/Dockerfile
@@ -1,0 +1,49 @@
+######## BUILDER ########
+
+# Set the base image
+FROM steamcmd/steamcmd:ubuntu-18 as builder
+
+# Set environment variables
+ENV USER root
+ENV HOME /root/installer
+
+# Set working directory
+WORKDIR $HOME
+
+# Install prerequisites
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl tar
+
+# Donload and unpack installer
+RUN curl http://media.steampowered.com/installer/steamcmd_linux.tar.gz \
+    --output steamcmd.tar.gz --silent
+RUN tar -xvzf steamcmd.tar.gz && rm steamcmd.tar.gz
+
+######## INSTALL ########
+
+# Set the base image
+FROM quay.io/centos/centos:stream8
+
+# Set environment variables
+ENV USER root
+ENV HOME /root
+
+# Install prerequisites
+RUN yum -y install glibc.i686 libgcc.i686 \
+ && yum -y clean all
+
+# Copy steamcmd files from builder
+COPY --from=builder /root/installer/steamcmd.sh /usr/lib/games/steam/
+COPY --from=builder /root/installer/linux32/steamcmd /usr/lib/games/steam/
+COPY --from=builder /usr/games/steamcmd /usr/bin/steamcmd
+
+# Copy required files from builder
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /root/installer/linux32/libstdc++.so.6 /lib/
+
+# Update SteamCMD and verify latest version
+RUN steamcmd +quit
+
+# Set default command
+ENTRYPOINT ["steamcmd"]
+CMD ["+help", "+quit"]

--- a/dockerfiles/centos-stream-9/Dockerfile
+++ b/dockerfiles/centos-stream-9/Dockerfile
@@ -1,0 +1,49 @@
+######## BUILDER ########
+
+# Set the base image
+FROM steamcmd/steamcmd:ubuntu-18 as builder
+
+# Set environment variables
+ENV USER root
+ENV HOME /root/installer
+
+# Set working directory
+WORKDIR $HOME
+
+# Install prerequisites
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl tar
+
+# Donload and unpack installer
+RUN curl http://media.steampowered.com/installer/steamcmd_linux.tar.gz \
+    --output steamcmd.tar.gz --silent
+RUN tar -xvzf steamcmd.tar.gz && rm steamcmd.tar.gz
+
+######## INSTALL ########
+
+# Set the base image
+FROM quay.io/centos/centos:stream9
+
+# Set environment variables
+ENV USER root
+ENV HOME /root
+
+# Install prerequisites
+RUN yum -y install glibc.i686 libgcc.i686 \
+ && yum -y clean all
+
+# Copy steamcmd files from builder
+COPY --from=builder /root/installer/steamcmd.sh /usr/lib/games/steam/
+COPY --from=builder /root/installer/linux32/steamcmd /usr/lib/games/steam/
+COPY --from=builder /usr/games/steamcmd /usr/bin/steamcmd
+
+# Copy required files from builder
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /root/installer/linux32/libstdc++.so.6 /lib/
+
+# Update SteamCMD and verify latest version
+RUN steamcmd +quit
+
+# Set default command
+ENTRYPOINT ["steamcmd"]
+CMD ["+help", "+quit"]


### PR DESCRIPTION
This PR will add CentOS Stream images to the list and automatic (every 6 hour) rebuild. For now the `centos-stream` images are separate from the regular `centos` images. Seeing Stream is the only type that will be supported in the future, the stream versions will eventually be used for the regular `centos` tags.

As an alternative to the CentOS stream variants, Rocky Linux can be used with the `rocky` or `rocky-8` tag.