### PR TITLE
Add Rocky 9 image support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,11 +103,11 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         run: for TAG in $IMAGE_TAG $IMAGE_TAG_ALT; do docker push steamcmd/steamcmd:${TAG}; done
 
-  build-rocky-8:
+  build-rocky-9:
     runs-on: ubuntu-18.04
     needs: build-ubuntu-18
     env:
-      IMAGE_TAG: "rocky-8"
+      IMAGE_TAG: "rocky-9"
       IMAGE_TAG_ALT: "rocky"
     steps:
       - uses: actions/checkout@v2
@@ -128,6 +128,28 @@ jobs:
       - name: Push Image
         if: ${{ github.ref == 'refs/heads/master' }}
         run: for TAG in $IMAGE_TAG $IMAGE_TAG_ALT; do docker push steamcmd/steamcmd:${TAG}; done
+
+  build-rocky-8:
+    runs-on: ubuntu-18.04
+    needs: build-ubuntu-18
+    env:
+      IMAGE_TAG: "rocky-8"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: e1himself/goss-installation-action@v1.0.3
+        with:
+          version: 'v0.3.14'
+      - name: Docker Login
+        run: echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Build Image
+        run: docker build -t steamcmd/steamcmd:$IMAGE_TAG .
+        working-directory: dockerfiles/${{ env.IMAGE_TAG }}
+      - name: Test Image
+        run: dgoss run steamcmd/steamcmd:$IMAGE_TAG --entrypoint=""
+      # master
+      - name: Push Image
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: docker push steamcmd/steamcmd:$IMAGE_TAG
 
   build-centos-9:
     runs-on: ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ have a look at [steamcmd.net](https://www.steamcmd.net).
 *   [`ubuntu-18`](dockerfiles/ubuntu-18/Dockerfile)
 *   [`ubuntu-16`](dockerfiles/ubuntu-16/Dockerfile)
 *   [`alpine-3`, `alpine`](dockerfiles/alpine-3/Dockerfile)
-*   [`rocky-8`, `rocky`](dockerfiles/rocky-8/Dockerfile)
+*   [`rocky-9`, `rocky`](dockerfiles/rocky-9/Dockerfile)
+*   [`rocky-8`](dockerfiles/rocky-8/Dockerfile)
 *   [`centos-9`, `centos`](dockerfiles/centos-9/Dockerfile)
 *   [`centos-8`](dockerfiles/centos-8/Dockerfile)
 *   [`windows-1909`](dockerfiles/windows-1909/Dockerfile) *(unavailable)*

--- a/dockerfiles/rocky-9/Dockerfile
+++ b/dockerfiles/rocky-9/Dockerfile
@@ -1,0 +1,49 @@
+######## BUILDER ########
+
+# Set the base image
+FROM steamcmd/steamcmd:ubuntu-18 as builder
+
+# Set environment variables
+ENV USER root
+ENV HOME /root/installer
+
+# Set working directory
+WORKDIR $HOME
+
+# Install prerequisites
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl tar
+
+# Donload and unpack installer
+RUN curl http://media.steampowered.com/installer/steamcmd_linux.tar.gz \
+    --output steamcmd.tar.gz --silent
+RUN tar -xvzf steamcmd.tar.gz && rm steamcmd.tar.gz
+
+######## INSTALL ########
+
+# Set the base image
+FROM rockylinux:9
+
+# Set environment variables
+ENV USER root
+ENV HOME /root
+
+# Install prerequisites
+RUN yum -y install glibc.i686 libgcc.i686 \
+ && yum -y clean all
+
+# Copy steamcmd files from builder
+COPY --from=builder /root/installer/steamcmd.sh /usr/lib/games/steam/
+COPY --from=builder /root/installer/linux32/steamcmd /usr/lib/games/steam/
+COPY --from=builder /usr/games/steamcmd /usr/bin/steamcmd
+
+# Copy required files from builder
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /root/installer/linux32/libstdc++.so.6 /lib/
+
+# Update SteamCMD and verify latest version
+RUN steamcmd +quit
+
+# Set default command
+ENTRYPOINT ["steamcmd"]
+CMD ["+help", "+quit"]


### PR DESCRIPTION
A new release of Rocky Linux has been released, version 9: https://docs.rockylinux.org/release_notes/9_0/. This PR will add another automatically build image to the list of existing distros.