### PR TITLE
Add Ubuntu 26.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: ubuntu-26
+            tags: "ubuntu-resolute latest"
           - name: ubuntu-24
-            tags: "ubuntu-noble ubuntu latest"
+            tags: "ubuntu-noble ubuntu stable"
           - name: ubuntu-22
             tags: "ubuntu-jammy"
           - name: ubuntu-20

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         include:
           - name: ubuntu-26
-            tags: "ubuntu-resolute latest"
+            tags: "ubuntu-resolute ubuntu latest"
           - name: ubuntu-24
-            tags: "ubuntu-noble ubuntu stable"
+            tags: "ubuntu-noble"
           - name: ubuntu-22
             tags: "ubuntu-jammy"
           - name: ubuntu-20

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ have a look at [steamcmd.net](https://www.steamcmd.net).
 
 ## Tags
 
-*   [`ubuntu-24`, `ubuntu-noble`, `ubuntu`, `latest`](dockerfiles/ubuntu-24/Dockerfile)
+*   [`ubuntu-26`, `ubuntu-resolute`, `latest`](dockerfiles/ubuntu-26/Dockerfile)
+*   [`ubuntu-24`, `ubuntu-noble`, `ubuntu`, `stable`](dockerfiles/ubuntu-24/Dockerfile)
 *   [`ubuntu-22`, `ubuntu-jammy`](dockerfiles/ubuntu-22/Dockerfile)
 *   [`ubuntu-20`, `ubuntu-focal`](dockerfiles/ubuntu-20/Dockerfile)
 *   [`debian-13`, `debian-trixie`, `debian`](dockerfiles/debian-13/Dockerfile)

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ have a look at [steamcmd.net](https://www.steamcmd.net).
 
 ## Tags
 
-*   [`ubuntu-26`, `ubuntu-resolute`, `latest`](dockerfiles/ubuntu-26/Dockerfile)
-*   [`ubuntu-24`, `ubuntu-noble`, `ubuntu`, `stable`](dockerfiles/ubuntu-24/Dockerfile)
+*   [`ubuntu-26`, `ubuntu-resolute`, `ubuntu`, `latest`](dockerfiles/ubuntu-26/Dockerfile)
+*   [`ubuntu-24`, `ubuntu-noble`](dockerfiles/ubuntu-24/Dockerfile)
 *   [`ubuntu-22`, `ubuntu-jammy`](dockerfiles/ubuntu-22/Dockerfile)
 *   [`ubuntu-20`, `ubuntu-focal`](dockerfiles/ubuntu-20/Dockerfile)
 *   [`debian-13`, `debian-trixie`, `debian`](dockerfiles/debian-13/Dockerfile)

--- a/dockerfiles/ubuntu-26/Dockerfile
+++ b/dockerfiles/ubuntu-26/Dockerfile
@@ -1,0 +1,46 @@
+######## INSTALL ########
+
+# Set the base image
+FROM ubuntu:26.04
+
+# Set environment variables
+ENV USER=root
+ENV HOME=/root
+
+# Set working directory
+WORKDIR $HOME
+
+# Insert Steam prompt answers
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN echo steam steam/question select "I AGREE" | debconf-set-selections \
+ && echo steam steam/license note '' | debconf-set-selections
+
+# Update the repository and install SteamCMD
+ARG DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update --quiet --yes \
+    && apt-get install --yes --no-install-recommends ca-certificates locales
+RUN apt-get install --yes steamcmd \
+    && rm --recursive --force /var/lib/apt/lists/*
+
+# Add unicode support
+RUN locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8'
+ENV LANGUAGE='en_US:en'
+
+# Create symlink for executable
+RUN ln --symbolic /usr/games/steamcmd /usr/bin/steamcmd
+
+# Update SteamCMD and verify latest version
+RUN steamcmd +quit
+
+# Fix missing directories and libraries
+RUN mkdir --parents $HOME/.steam \
+    && ln --symbolic $HOME/.local/share/Steam/steamcmd/linux32 $HOME/.steam/sdk32 \
+    && ln --symbolic $HOME/.local/share/Steam/steamcmd/linux64 $HOME/.steam/sdk64 \
+    && ln --symbolic $HOME/.steam/sdk32/steamclient.so $HOME/.steam/sdk32/steamservice.so \
+    && ln --symbolic $HOME/.steam/sdk64/steamclient.so $HOME/.steam/sdk64/steamservice.so
+
+# Set default command
+ENTRYPOINT ["steamcmd"]
+CMD ["+help", "+quit"]

--- a/dockerfiles/ubuntu-26/Dockerfile
+++ b/dockerfiles/ubuntu-26/Dockerfile
@@ -13,14 +13,13 @@ WORKDIR $HOME
 # Insert Steam prompt answers
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo steam steam/question select "I AGREE" | debconf-set-selections \
- && echo steam steam/license note '' | debconf-set-selections
+    && echo steam steam/license note '' | debconf-set-selections
 
 # Update the repository and install SteamCMD
 ARG DEBIAN_FRONTEND=noninteractive
 RUN dpkg --add-architecture i386 \
-    && apt-get update --quiet --yes \
-    && apt-get install --yes --no-install-recommends ca-certificates locales
-RUN apt-get install --yes steamcmd \
+    && apt-get update --quiet --quiet \
+    && apt-get install --yes --no-install-recommends ca-certificates locales steamcmd \
     && rm --recursive --force /var/lib/apt/lists/*
 
 # Add unicode support
@@ -35,11 +34,11 @@ RUN ln --symbolic /usr/games/steamcmd /usr/bin/steamcmd
 RUN steamcmd +quit
 
 # Fix missing directories and libraries
-RUN mkdir --parents $HOME/.steam \
-    && ln --symbolic $HOME/.local/share/Steam/steamcmd/linux32 $HOME/.steam/sdk32 \
-    && ln --symbolic $HOME/.local/share/Steam/steamcmd/linux64 $HOME/.steam/sdk64 \
-    && ln --symbolic $HOME/.steam/sdk32/steamclient.so $HOME/.steam/sdk32/steamservice.so \
-    && ln --symbolic $HOME/.steam/sdk64/steamclient.so $HOME/.steam/sdk64/steamservice.so
+RUN mkdir --parents "$HOME/.steam" \
+    && ln --symbolic "$HOME/.local/share/Steam/steamcmd/linux32" "$HOME/.steam/sdk32" \
+    && ln --symbolic "$HOME/.local/share/Steam/steamcmd/linux64" "$HOME/.steam/sdk64" \
+    && ln --symbolic "$HOME/.steam/sdk32/steamclient.so" "$HOME/.steam/sdk32/steamservice.so" \
+    && ln --symbolic "$HOME/.steam/sdk64/steamclient.so" "$HOME/.steam/sdk64/steamservice.so"
 
 # Set default command
 ENTRYPOINT ["steamcmd"]


### PR DESCRIPTION
* Added Ubuntu 26.04 (Resolute) image.
* Updated GitHub workflows.
    * 24.04 is now tagged `ubuntu` and `stable`.
    * 26.04 is tagged `latest`.
* Updated README.md.

I've tested this new image locally with Satisfactory, and it seems to work fine.